### PR TITLE
Readme Change - clearly indicate folder in @import line

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ The `.css` extension triggers special behavior in Sass so you cannot
 import a file with a CSS extension. To work around this, you must use a
 special prefix on the import string and omit the extension.
 
-    @import "CSS:library/some_css_file"
+    @import "CSS:some_folder/some_css_file"
 
 ## Installation
 


### PR DESCRIPTION
Had a little trouble getting started as I didn't get that 'library' was the name of a folder. I had thought that 'library' was part of the syntax. In my defence 'CSS:library' sounds like it could be a thing.

Small change to make it clearer in readme.

You can decide if I was just super thick or it is a little unclear.
