### PR TITLE
Import CSS files from all specified load paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .bundle
 Gemfile.lock
 pkg/*
+bin/
+vendor/

--- a/lib/sass/css_importer/monkey_patches.rb
+++ b/lib/sass/css_importer/monkey_patches.rb
@@ -9,8 +9,11 @@ class Sass::Engine
     css_importer = self.options[:load_paths].find {|lp| lp.is_a?(Sass::CssImporter::Importer) }
 
     unless css_importer
-      root = File.dirname(options[:filename] || ".")
-      self.options[:load_paths] << Sass::CssImporter::Importer.new(root)
+      css_importers =
+        self.options[:load_paths].map do |importer|
+          Sass::CssImporter::Importer.new(importer.root)
+        end
+      self.options[:load_paths].concat css_importers
     end
   end
 end


### PR DESCRIPTION
Currently the importer just looks in the cwd for CSS files, this change allows makes it look in all load paths. This will help users who have `bower_components` on their load path.
